### PR TITLE
Add support for mentionable select menus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "necord",
 	"description": "A module for creating Discord bots using NestJS, based on Discord.js.",
-	"version": "5.3.1",
+	"version": "5.4.0",
 	"scripts": {
 		"build": "rimraf -rf dist && tsc -p tsconfig.json",
 		"prepublish:npm": "npm run build",

--- a/src/message-components/decorators/index.ts
+++ b/src/message-components/decorators/index.ts
@@ -3,3 +3,4 @@ export * from './component-param.decorator';
 export * from './message-component.decorator';
 export * from './select-menu.decorator';
 export * from './values.decorator';
+export * from './selected.decorator';

--- a/src/message-components/decorators/select-menu.decorator.ts
+++ b/src/message-components/decorators/select-menu.decorator.ts
@@ -1,5 +1,24 @@
 import { ComponentType } from 'discord.js';
 import { MessageComponent } from './message-component.decorator';
 
+/**
+ *  @deprecated since 5.4 - This is the old name for @StringSelect
+ *  Will be deleted in version 6
+ */
 export const SelectMenu = (customId: string) =>
 	MessageComponent({ customId, type: ComponentType.SelectMenu });
+
+export const StringSelect = (customId: string) =>
+	MessageComponent({ customId, type: ComponentType.StringSelect });
+
+export const ChannelSelect = (customId: string) =>
+	MessageComponent({ customId, type: ComponentType.ChannelSelect });
+
+export const UserSelect = (customId: string) =>
+	MessageComponent({ customId, type: ComponentType.UserSelect });
+
+export const MentionableSelect = (customId: string) =>
+	MessageComponent({ customId, type: ComponentType.MentionableSelect });
+
+export const RoleSelect = (customId: string) =>
+	MessageComponent({ customId, type: ComponentType.RoleSelect });

--- a/src/message-components/decorators/select-menu.decorator.ts
+++ b/src/message-components/decorators/select-menu.decorator.ts
@@ -2,11 +2,13 @@ import { ComponentType } from 'discord.js';
 import { MessageComponent } from './message-component.decorator';
 
 /**
- *  @deprecated since 5.4 - This is the old name for StringSelect. Will be deleted in v6
- *  TODO: Remove in v6
+ *  @deprecated since 5.4 - This is the old name for StringSelect. Will be deleted in v6. Discord now uses new select menus
+ *  @see {@link https://discord.js.org/#/docs/discord.js/main/class/SelectMenuInteraction DiscordJS docs}
+ *  @see {@link https://discord.com/developers/docs/interactions/message-components#select-menus Discord API docs}
+ *  @see {@link https://discord.com/developers/docs/interactions/message-components#component-object-component-types ComponentType}
  */
 export const SelectMenu = (customId: string) =>
-	MessageComponent({ customId, type: ComponentType.SelectMenu });
+	MessageComponent({ customId, type: ComponentType.SelectMenu }); // TODO: Remove in v6
 
 export const StringSelect = (customId: string) =>
 	MessageComponent({ customId, type: ComponentType.StringSelect });

--- a/src/message-components/decorators/select-menu.decorator.ts
+++ b/src/message-components/decorators/select-menu.decorator.ts
@@ -2,8 +2,8 @@ import { ComponentType } from 'discord.js';
 import { MessageComponent } from './message-component.decorator';
 
 /**
- *  @deprecated since 5.4 - This is the old name for @StringSelect
- *  Will be deleted in version 6
+ *  @deprecated since 5.4 - This is the old name for StringSelect.
+ *  Will be deleted in v6
  */
 export const SelectMenu = (customId: string) =>
 	MessageComponent({ customId, type: ComponentType.SelectMenu });

--- a/src/message-components/decorators/select-menu.decorator.ts
+++ b/src/message-components/decorators/select-menu.decorator.ts
@@ -2,8 +2,8 @@ import { ComponentType } from 'discord.js';
 import { MessageComponent } from './message-component.decorator';
 
 /**
- *  @deprecated since 5.4 - This is the old name for StringSelect.
- *  Will be deleted in v6
+ *  @deprecated since 5.4 - This is the old name for StringSelect. Will be deleted in v6
+ *  TODO: Remove in v6
  */
 export const SelectMenu = (customId: string) =>
 	MessageComponent({ customId, type: ComponentType.SelectMenu });

--- a/src/message-components/decorators/selected.decorator.ts
+++ b/src/message-components/decorators/selected.decorator.ts
@@ -1,6 +1,13 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { NecordExecutionContext } from '../../context';
 
+export const SelectedStrings = createParamDecorator((_, ctx: ExecutionContext) => {
+	const necordContext = NecordExecutionContext.create(ctx);
+	const [interaction] = necordContext.getContext<'interactionCreate'>();
+
+	return interaction.isStringSelectMenu() ? interaction.values : [];
+});
+
 export const SelectedChannels = createParamDecorator((_, ctx: ExecutionContext) => {
 	const necordContext = NecordExecutionContext.create(ctx);
 	const [interaction] = necordContext.getContext<'interactionCreate'>();

--- a/src/message-components/decorators/selected.decorator.ts
+++ b/src/message-components/decorators/selected.decorator.ts
@@ -1,0 +1,41 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { NecordExecutionContext } from '../../context';
+
+export const SelectedChannels = createParamDecorator((_, ctx: ExecutionContext) => {
+	const necordContext = NecordExecutionContext.create(ctx);
+	const [interaction] = necordContext.getContext<'interactionCreate'>();
+
+	return interaction.isChannelSelectMenu() ? interaction.channels : [];
+});
+
+export const SelectedUsers = createParamDecorator((_, ctx: ExecutionContext) => {
+	const necordContext = NecordExecutionContext.create(ctx);
+	const [interaction] = necordContext.getContext<'interactionCreate'>();
+
+	if (interaction.isUserSelectMenu() || interaction.isMentionableSelectMenu()) {
+		return interaction.users;
+	}
+
+	return [];
+});
+
+export const SelectedMembers = createParamDecorator((_, ctx: ExecutionContext) => {
+	const necordContext = NecordExecutionContext.create(ctx);
+	const [interaction] = necordContext.getContext<'interactionCreate'>();
+
+	if (interaction.isUserSelectMenu() || interaction.isMentionableSelectMenu()) {
+		return interaction.users;
+	}
+	return [];
+});
+
+export const SelectedRoles = createParamDecorator((_, ctx: ExecutionContext) => {
+	const necordContext = NecordExecutionContext.create(ctx);
+	const [interaction] = necordContext.getContext<'interactionCreate'>();
+
+	if (interaction.isRoleSelectMenu() || interaction.isMentionableSelectMenu()) {
+		return interaction.roles;
+	}
+
+	return [];
+});

--- a/src/message-components/decorators/values.decorator.ts
+++ b/src/message-components/decorators/values.decorator.ts
@@ -5,5 +5,5 @@ export const Values = createParamDecorator((_, ctx: ExecutionContext) => {
 	const necordContext = NecordExecutionContext.create(ctx);
 	const [interaction] = necordContext.getContext<'interactionCreate'>();
 
-	return interaction.isSelectMenu() ? interaction.values : [];
+	return interaction.isAnySelectMenu() ? interaction.values : [];
 });

--- a/src/message-components/decorators/values.decorator.ts
+++ b/src/message-components/decorators/values.decorator.ts
@@ -1,9 +1,13 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { NecordExecutionContext } from '../../context';
 
+/**
+ * @deprecate since v5.4 - old name for `@SelectedStrings`. Will be removed in v6
+ * TODO: Remove in v6
+ */
 export const Values = createParamDecorator((_, ctx: ExecutionContext) => {
 	const necordContext = NecordExecutionContext.create(ctx);
 	const [interaction] = necordContext.getContext<'interactionCreate'>();
 
-	return interaction.isAnySelectMenu() ? interaction.values : [];
+	return interaction.isStringSelectMenu() ? interaction.values : [];
 });

--- a/src/message-components/decorators/values.decorator.ts
+++ b/src/message-components/decorators/values.decorator.ts
@@ -1,9 +1,12 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { NecordExecutionContext } from '../../context';
 
+// TODO: Remove in v6
 /**
- * @deprecate since v5.4 - old name for `@SelectedStrings`. Will be removed in v6
- * TODO: Remove in v6
+ *  @deprecated since v5.4 - old name for `@SelectedStrings`. Will be removed in v6. Discord now uses new select menus
+ *  @see {@link https://discord.js.org/#/docs/discord.js/main/class/SelectMenuInteraction DiscordJS docs}
+ *  @see {@link https://discord.com/developers/docs/interactions/message-components#select-menus Discord API docs}
+ *  @see {@link https://discord.com/developers/docs/interactions/message-components#component-object-component-types ComponentType}
  */
 export const Values = createParamDecorator((_, ctx: ExecutionContext) => {
 	const necordContext = NecordExecutionContext.create(ctx);

--- a/src/message-components/message-component.discovery.ts
+++ b/src/message-components/message-component.discovery.ts
@@ -3,7 +3,7 @@ import { match } from 'path-to-regexp';
 import { NecordBaseDiscovery } from '../context';
 
 export interface MessageComponentMeta {
-	type: Exclude<MessageComponentType, ComponentType.ActionRow>;
+	type: Exclude<MessageComponentType, ComponentType.ActionRow | ComponentType.TextInput>;
 	customId: string;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
New selection menu types (user,channel,role,mentionables) are recently added as a feature in DJS v14.7.0
This PR adds relevant component discovery decorators and param decorators to make it possible to use these newly added selection menus

**Status and versioning classification:**
- `.isSelectMenu()` and `ComponentType.SelectMenu` have been marked deprecated in DJS v14.7.0. 
So accordingly `@SelectMenu` has been marked deprecated in this PR.
- `interaction.values` return different types depending upon SelectMenuInteraction/UserSelectMenuInteraction
`@Values` is marked deprecated in favour of `@SelectedStrings`

`v5.4.0`
I have not bumped package.json yet to prevent conflicts with dependabot's PR

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
