### PR TITLE
Add contexts and param types for select menus

### DIFF
--- a/src/context/necord-context.interface.ts
+++ b/src/context/necord-context.interface.ts
@@ -1,12 +1,17 @@
 import {
 	AutocompleteInteraction,
 	ButtonInteraction,
+	ChannelSelectMenuInteraction,
 	ChatInputCommandInteraction,
+	MentionableSelectMenuInteraction,
 	Message,
 	MessageContextMenuCommandInteraction,
 	ModalSubmitInteraction,
+	RoleSelectMenuInteraction,
 	SelectMenuInteraction,
-	UserContextMenuCommandInteraction
+	StringSelectMenuInteraction,
+	UserContextMenuCommandInteraction,
+	UserSelectMenuInteraction
 } from 'discord.js';
 import { NecordEvents } from '../listeners/listener.interface';
 
@@ -24,6 +29,23 @@ export type ModalContext = [ModalSubmitInteraction];
 
 export type ButtonContext = [ButtonInteraction];
 
+// TODO: Remove in v6
+/**
+ *  @deprecated since v5.4 - old name for `StringSelectContext`. Will be removed in v6. Discord now uses new select menus
+ *  @see {@link https://discord.js.org/#/docs/discord.js/main/class/SelectMenuInteraction DiscordJS docs}
+ *  @see {@link https://discord.com/developers/docs/interactions/message-components#select-menus Discord API docs}
+ *  @see {@link https://discord.com/developers/docs/interactions/message-components#component-object-component-types ComponentType}
+ */
 export type SelectMenuContext = [SelectMenuInteraction];
+
+export type StringSelectContext = [StringSelectMenuInteraction];
+
+export type ChannelSelectContext = [ChannelSelectMenuInteraction];
+
+export type RoleSelectContext = [RoleSelectMenuInteraction];
+
+export type UserSelectContext = [UserSelectMenuInteraction];
+
+export type MentionableSelectContext = [MentionableSelectMenuInteraction];
 
 export type ContextOf<K extends keyof E, E = NecordEvents> = E[K];

--- a/src/message-components/decorators/selected.decorator.ts
+++ b/src/message-components/decorators/selected.decorator.ts
@@ -1,4 +1,10 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import {
+	ChannelSelectMenuInteraction,
+	MentionableSelectMenuInteraction,
+	RoleSelectMenuInteraction,
+	UserSelectMenuInteraction
+} from 'discord.js';
 import { NecordExecutionContext } from '../../context';
 
 export const SelectedStrings = createParamDecorator((_, ctx: ExecutionContext) => {
@@ -14,6 +20,7 @@ export const SelectedChannels = createParamDecorator((_, ctx: ExecutionContext) 
 
 	return interaction.isChannelSelectMenu() ? interaction.channels : [];
 });
+export type ISelectedChannels = ChannelSelectMenuInteraction['channels'];
 
 export const SelectedUsers = createParamDecorator((_, ctx: ExecutionContext) => {
 	const necordContext = NecordExecutionContext.create(ctx);
@@ -25,6 +32,9 @@ export const SelectedUsers = createParamDecorator((_, ctx: ExecutionContext) => 
 
 	return [];
 });
+export type ISelectedUsers =
+	| UserSelectMenuInteraction['users']
+	| MentionableSelectMenuInteraction['users'];
 
 export const SelectedMembers = createParamDecorator((_, ctx: ExecutionContext) => {
 	const necordContext = NecordExecutionContext.create(ctx);
@@ -35,6 +45,9 @@ export const SelectedMembers = createParamDecorator((_, ctx: ExecutionContext) =
 	}
 	return [];
 });
+export type ISelectedMembers =
+	| UserSelectMenuInteraction['members']
+	| MentionableSelectMenuInteraction['members'];
 
 export const SelectedRoles = createParamDecorator((_, ctx: ExecutionContext) => {
 	const necordContext = NecordExecutionContext.create(ctx);
@@ -46,3 +59,6 @@ export const SelectedRoles = createParamDecorator((_, ctx: ExecutionContext) => 
 
 	return [];
 });
+export type ISelectedRoles =
+	| RoleSelectMenuInteraction['roles']
+	| MentionableSelectMenuInteraction['roles'];

--- a/test/message-components.spec.ts
+++ b/test/message-components.spec.ts
@@ -1,15 +1,44 @@
 import {
 	Button,
 	ButtonContext,
+	ChannelSelect,
+	ChannelSelectContext,
 	ComponentParam,
 	Context,
+	ISelectedChannels,
+	ISelectedMembers,
+	ISelectedRoles,
+	ISelectedUsers,
+	MentionableSelect,
+	MentionableSelectContext,
+	RoleSelect,
+	RoleSelectContext,
+	SelectedChannels,
+	SelectedMembers,
+	SelectedRoles,
+	SelectedStrings,
+	SelectedUsers,
 	SelectMenu,
 	SelectMenuContext,
 	SlashCommand,
-	SlashCommandContext
+	SlashCommandContext,
+	StringSelect,
+	StringSelectContext,
+	UserSelectContext
 } from '../src';
 import { Injectable } from '@nestjs/common';
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, SelectMenuBuilder } from 'discord.js';
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	ChannelSelectMenuBuilder,
+	ChannelType,
+	MentionableSelectMenuBuilder,
+	RoleSelectMenuBuilder,
+	SelectMenuBuilder,
+	StringSelectMenuBuilder,
+	UserSelectMenuBuilder
+} from 'discord.js';
 import { MessageActionRowComponentBuilder } from '@discordjs/builders';
 import { createApplication } from './utils.spec';
 
@@ -59,10 +88,166 @@ export class MessageComponentsSpec {
 		return interaction.reply({ content: `Button clicked! Value: ${value}` });
 	}
 
+	// TODO: Remove in v6
+	/**
+	 *  @deprecated since v5.4 - old name for `@SelectedStrings`. Will be removed in v6. Discord now uses new select menus
+	 *  @see {@link https://discord.js.org/#/docs/discord.js/main/class/SelectMenuInteraction DiscordJS docs}
+	 *  @see {@link https://discord.com/developers/docs/interactions/message-components#select-menus Discord API docs}
+	 *  @see {@link https://discord.com/developers/docs/interactions/message-components#component-object-component-types ComponentType}
+	 */
 	@SelectMenu('SELECT_MENU')
 	public onSelectMenu(@Context() [interaction]: SelectMenuContext) {
 		return interaction.reply({
 			content: `Your selected color - ${interaction.values.join(' ')}`
+		});
+	}
+
+	@SlashCommand({ name: 'string-select', description: 'Creates string select menu component.' })
+	public async createStringSelect(@Context() [interaction]: SlashCommandContext) {
+		return interaction.reply({
+			content: `String Select Menu`,
+			components: [
+				new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents([
+					new StringSelectMenuBuilder()
+						.setCustomId('STRING_SELECT_MENU')
+						.setPlaceholder('Select your color')
+						.setMaxValues(1)
+						.setMinValues(1)
+						.setOptions([
+							{ label: 'Red', value: 'Red' },
+							{ label: 'Blue', value: 'Blue' },
+							{ label: 'Yellow', value: 'Yellow' }
+						])
+				])
+			]
+		});
+	}
+
+	@StringSelect('STRING_SELECT_MENU')
+	public onStringSelect(
+		@Context() [interaction]: StringSelectContext,
+		@SelectedStrings() selected: string[]
+	) {
+		return interaction.reply({
+			content: `Your selected color - ${selected.join(' ')}`
+		});
+	}
+
+	@SlashCommand({ name: 'channel-select', description: 'Creates channel select menu component.' })
+	public async createChannelSelect(@Context() [interaction]: SlashCommandContext) {
+		return interaction.reply({
+			content: `Channel Select Menu`,
+			components: [
+				new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents([
+					new ChannelSelectMenuBuilder()
+						.setCustomId('CHANNEL_SELECT_MENU')
+						.setPlaceholder('Select a text channel')
+						.setMaxValues(1)
+						.setMinValues(1)
+						.setChannelTypes(ChannelType.GuildText)
+				])
+			]
+		});
+	}
+
+	@ChannelSelect('CHANNEL_SELECT_MENU')
+	public onChannelSelect(
+		@Context() [interaction]: ChannelSelectContext,
+		@SelectedChannels() channels: ISelectedChannels
+	) {
+		return interaction.reply({
+			content: `Your selected channels - ${channels.map(ch => ch.id).join(',')}`
+		});
+	}
+
+	@SlashCommand({ name: 'user-select', description: 'Creates user select menu component.' })
+	public async createUserSelect(@Context() [interaction]: SlashCommandContext) {
+		return interaction.reply({
+			content: `User Select Menu`,
+			components: [
+				new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents([
+					new UserSelectMenuBuilder()
+						.setCustomId('USER_SELECT_MENU')
+						.setPlaceholder('Select a user')
+						.setMaxValues(1)
+						.setMinValues(1)
+				])
+			]
+		});
+	}
+
+	@RoleSelect('USER_SELECT_MENU')
+	public onUserSelect(
+		@Context() [interaction]: UserSelectContext,
+		@SelectedUsers() users: ISelectedUsers,
+		@SelectedMembers() members: ISelectedMembers
+	) {
+		interaction.reply({
+			content: `
+      Your selected users - ${users.map(user => user.username).join(',')}\n
+      Your selected members - ${members.map(member => member.user?.username).join(',')}
+      `
+		});
+	}
+
+	@SlashCommand({ name: 'role-select', description: 'Creates role select menu component.' })
+	public async createRoleSelect(@Context() [interaction]: SlashCommandContext) {
+		return interaction.reply({
+			content: `Role Select Menu`,
+			components: [
+				new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents([
+					new RoleSelectMenuBuilder()
+						.setCustomId('ROLE_SELECT_MENU')
+						.setPlaceholder('Select a role')
+						.setMaxValues(1)
+						.setMinValues(1)
+				])
+			]
+		});
+	}
+
+	@RoleSelect('ROLE_SELECT_MENU')
+	public onRoleSelect(
+		@Context() [interaction]: RoleSelectContext,
+		@SelectedRoles() roles: ISelectedRoles
+	) {
+		return interaction.reply({
+			content: `Your selected roles - ${roles.map(role => role.name).join(',')}`
+		});
+	}
+
+	@SlashCommand({
+		name: 'mentionable-select',
+		description: 'Creates mentionable select menu component.'
+	})
+	public async createMentionableSelect(@Context() [interaction]: SlashCommandContext) {
+		return interaction.reply({
+			content: `Mentionable Select Menu`,
+			components: [
+				new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents([
+					new MentionableSelectMenuBuilder()
+						.setCustomId('MENTIONABLE_SELECT_MENU')
+						.setPlaceholder('Select a mentionable (user or role)')
+						.setMaxValues(1)
+						.setMinValues(1)
+				])
+			]
+		});
+	}
+
+	@MentionableSelect('MENTIONABLE_SELECT_MENU')
+	public onMentionableSelect(
+		@Context() [interaction]: MentionableSelectContext,
+		@SelectedUsers() users: ISelectedUsers,
+		@SelectedUsers() members: ISelectedMembers,
+		@SelectedRoles() roles: ISelectedRoles
+	) {
+		return interaction.reply({
+			content: `
+      Selected roles - ${roles.map(role => role.name).join(',')}\n
+      Selected users - ${users.map(user => user.username).join(',')}\n
+      Selected members - ${members.map(member => member.user?.username).join(',')}
+      `
 		});
 	}
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

1. Context interface for new select menus
   - `StringSelectContext`
   - `ChannelSelectContext`
   - `RoleSelectContext`
   - `UserSelectContext`
   - `MentionableSelectContext`

2. Helper types for parameter decorators
   - `ISelectedChannels` 
   - `ISelectedRoles` 
   - `ISelectedUsers` 
   - `ISelectedMembers` 
   
 3. Examples for new select menus
 
**Status and versioning classification:**
   - `SelectContext` marked as deprecated
 
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
