### PR TITLE
fix: SelectedMembers decorator was returning users

### DIFF
--- a/src/message-components/decorators/selected.decorator.ts
+++ b/src/message-components/decorators/selected.decorator.ts
@@ -41,7 +41,7 @@ export const SelectedMembers = createParamDecorator((_, ctx: ExecutionContext) =
 	const [interaction] = necordContext.getContext<'interactionCreate'>();
 
 	if (interaction.isUserSelectMenu() || interaction.isMentionableSelectMenu()) {
-		return interaction.users;
+		return interaction.members;
 	}
 	return [];
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- The SelectedMembers decorator was returning users, but according to typing, it should return members

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
