### PR TITLE
Splitting guildAuditLogEntryCreate into three events (#709

### DIFF
--- a/src/listeners/listener.interface.ts
+++ b/src/listeners/listener.interface.ts
@@ -2,6 +2,7 @@ import {
 	ClientEvents,
 	DMChannel,
 	Guild,
+	GuildAuditLogsEntry,
 	GuildFeature,
 	GuildMember,
 	GuildPremiumTier,
@@ -124,4 +125,9 @@ export interface NecordEvents extends ClientEvents {
 	voiceChannelUndeaf: [member: GuildMember, type: 'self-deafed' | 'server-deafed'];
 	voiceStreamingStart: [member: GuildMember, channel: VoiceBasedChannel];
 	voiceStreamingStop: [member: GuildMember, channel: VoiceBasedChannel];
+
+	// Audit Log Entry
+	GuildAuditLogsEntryTypeCreate: [auditLogEntry: GuildAuditLogsEntry, guild: Guild];
+	GuildAuditLogsEntryTypeUpdate: [auditLogEntry: GuildAuditLogsEntry, guild: Guild];
+	GuildAuditLogsEntryTypeDelete: [auditLogEntry: GuildAuditLogsEntry, guild: Guild];
 }

--- a/src/listeners/listener.interface.ts
+++ b/src/listeners/listener.interface.ts
@@ -127,7 +127,7 @@ export interface NecordEvents extends ClientEvents {
 	voiceStreamingStop: [member: GuildMember, channel: VoiceBasedChannel];
 
 	// Audit Log Entry
-	GuildAuditLogsEntryTypeCreate: [auditLogEntry: GuildAuditLogsEntry, guild: Guild];
-	GuildAuditLogsEntryTypeUpdate: [auditLogEntry: GuildAuditLogsEntry, guild: Guild];
-	GuildAuditLogsEntryTypeDelete: [auditLogEntry: GuildAuditLogsEntry, guild: Guild];
+	guildAuditLogsEntryTypeCreate: [auditLogEntry: GuildAuditLogsEntry, guild: Guild];
+	guildAuditLogsEntryTypeUpdate: [auditLogEntry: GuildAuditLogsEntry, guild: Guild];
+	guildAuditLogsEntryTypeDelete: [auditLogEntry: GuildAuditLogsEntry, guild: Guild];
 }

--- a/src/listeners/listeners.service.ts
+++ b/src/listeners/listeners.service.ts
@@ -352,15 +352,15 @@ export class ListenersService implements OnModuleInit, OnApplicationBootstrap {
 		const { actionType } = auditLogEntry;
 
 		if(actionType == 'Create') {
-			this.emit('GuildAuditLogsEntryTypeCreate', auditLogEntry, guild);
+			this.emit('guildAuditLogsEntryTypeCreate', auditLogEntry, guild);
 		}
 
 		if(actionType == 'Delete') {
-			this.emit('GuildAuditLogsEntryTypeDelete', auditLogEntry, guild);
+			this.emit('guildAuditLogsEntryTypeDelete', auditLogEntry, guild);
 		}
 
 		if(actionType == 'Update') {
-			this.emit('GuildAuditLogsEntryTypeUpdate', auditLogEntry, guild);
+			this.emit('guildAuditLogsEntryTypeUpdate', auditLogEntry, guild);
 		}
 	}
 }

--- a/src/listeners/listeners.service.ts
+++ b/src/listeners/listeners.service.ts
@@ -33,6 +33,7 @@ export class ListenersService implements OnModuleInit, OnApplicationBootstrap {
 		this.on('threadUpdate', this.onThreadUpdate);
 		this.on('userUpdate', this.onUserUpdate);
 		this.on('voiceStateUpdate', this.onVoiceStateUpdate);
+		this.on('guildAuditLogEntryCreate', this.onGuildAuditLogEntryCreate);
 	}
 
 	private on<K extends keyof NecordEvents>(event: K, fn: (args: NecordEvents[K]) => void) {
@@ -344,6 +345,22 @@ export class ListenersService implements OnModuleInit, OnApplicationBootstrap {
 
 		if (oldState.streaming && !newState.streaming) {
 			this.emit('voiceStreamingStop', newMember, newState.channel);
+		}
+	}
+
+	private onGuildAuditLogEntryCreate([auditLogEntry, guild]: ContextOf<'guildAuditLogEntryCreate'>) {
+		const { actionType } = auditLogEntry;
+
+		if(actionType == 'Create') {
+			this.emit('GuildAuditLogsEntryTypeCreate', auditLogEntry, guild);
+		}
+
+		if(actionType == 'Delete') {
+			this.emit('GuildAuditLogsEntryTypeDelete', auditLogEntry, guild);
+		}
+
+		if(actionType == 'Update') {
+			this.emit('GuildAuditLogsEntryTypeUpdate', auditLogEntry, guild);
 		}
 	}
 }

--- a/src/listeners/listeners.service.ts
+++ b/src/listeners/listeners.service.ts
@@ -351,16 +351,21 @@ export class ListenersService implements OnModuleInit, OnApplicationBootstrap {
 	private onGuildAuditLogEntryCreate([auditLogEntry, guild]: ContextOf<'guildAuditLogEntryCreate'>) {
 		const { actionType } = auditLogEntry;
 
-		if(actionType == 'Create') {
-			this.emit('guildAuditLogsEntryTypeCreate', auditLogEntry, guild);
-		}
+		switch (actionType) {
+			case "Create":
+				this.emit('guildAuditLogsEntryTypeCreate', auditLogEntry, guild);
+				break;
 
-		if(actionType == 'Delete') {
-			this.emit('guildAuditLogsEntryTypeDelete', auditLogEntry, guild);
-		}
+			case "Delete":
+				this.emit('guildAuditLogsEntryTypeDelete', auditLogEntry, guild);
+				break;
 
-		if(actionType == 'Update') {
-			this.emit('guildAuditLogsEntryTypeUpdate', auditLogEntry, guild);
+			case "Update":
+				this.emit('guildAuditLogsEntryTypeUpdate', auditLogEntry, guild);
+				break;
+
+			default:
+				break;
 		}
 	}
 }


### PR DESCRIPTION
**Feature**

Split `guildAuditLogEntryCreate` into three events `GuildAuditLogsEntryTypeCreate`, `GuildAuditLogsEntryTypeUpdate`, `GuildAuditLogsEntryTypeDelete`.

