### PR TITLE
feat: added aliases to text commands

### DIFF
--- a/src/necord-options.interface.ts
+++ b/src/necord-options.interface.ts
@@ -14,6 +14,10 @@ export interface NecordModuleOptions extends DiscordClientOptions {
 	 */
 	prefix?: string | Function;
 	/**
+	 * Allows text commands to be used without a prefix when enabled.
+	 */
+	allowTextCommandsWithoutPrefix?: boolean;
+	/**
 	 * As discord caches application commands for up to an hour, it is recommended to specify a development guild when doing development.
 	 *
 	 * * If you do not specify a development guild, your commands and their arguments are likely to be outdated.

--- a/src/text-commands/text-command.discovery.ts
+++ b/src/text-commands/text-command.discovery.ts
@@ -3,6 +3,7 @@ import { NecordBaseDiscovery } from '../context';
 export interface TextCommandMeta {
 	name: string;
 	description: string;
+	aliases?: string[];
 }
 
 /**
@@ -15,6 +16,10 @@ export class TextCommandDiscovery extends NecordBaseDiscovery<TextCommandMeta> {
 
 	public getDescription() {
 		return this.meta.description;
+	}
+
+	public getAliases() {
+		return this.meta.aliases;
 	}
 
 	public override isTextCommand(): this is TextCommandDiscovery {

--- a/src/text-commands/text-command.discovery.ts
+++ b/src/text-commands/text-command.discovery.ts
@@ -19,7 +19,7 @@ export class TextCommandDiscovery extends NecordBaseDiscovery<TextCommandMeta> {
 	}
 
 	public getAliases() {
-		return this.meta.aliases;
+		return this.meta.aliases ?? [];
 	}
 
 	public override isTextCommand(): this is TextCommandDiscovery {

--- a/src/text-commands/text-commands.module.ts
+++ b/src/text-commands/text-commands.module.ts
@@ -22,12 +22,10 @@ export class TextCommandsModule implements OnApplicationBootstrap, OnModuleInit 
 		private readonly textCommandsService: TextCommandsService
 	) {}
 
-	public onModuleInit() {
-		const prefix = (this.options.prefix ?? '!');
-
+	public async onModuleInit() {
 		return this.explorerService
 			.explore(TextCommand.KEY)
-			.forEach(textCommand => this.textCommandsService.add(textCommand, prefix));
+			.forEach(textCommand => this.textCommandsService.add(textCommand));
 	}
 
 	public onApplicationBootstrap() {
@@ -36,9 +34,23 @@ export class TextCommandsModule implements OnApplicationBootstrap, OnModuleInit 
 				return;
 
 			const content = message.content.toLowerCase();
+			
+			let args: string[] = [];
+			let cmd: string | undefined;
 
-			const args = content.split(/ +/g);
-			const cmd = args.shift();
+			const prefix =
+				typeof this.options.prefix !== 'function'
+					? (this.options.prefix ?? '!')
+					: await this.options.prefix(message);
+
+			if (prefix && content.startsWith(prefix)) {
+				const contentWithoutPrefix = content.slice(prefix.length);
+				args = contentWithoutPrefix.split(/ +/g);
+				cmd = args.shift();
+			} else {
+				args = content.split(/ +/g);
+				cmd = args.shift();
+			}
 
 			if (!cmd) return;
 

--- a/src/text-commands/text-commands.module.ts
+++ b/src/text-commands/text-commands.module.ts
@@ -23,9 +23,11 @@ export class TextCommandsModule implements OnApplicationBootstrap, OnModuleInit 
 	) {}
 
 	public onModuleInit() {
+		const prefix = (this.options.prefix ?? '!');
+
 		return this.explorerService
 			.explore(TextCommand.KEY)
-			.forEach(textCommand => this.textCommandsService.add(textCommand));
+			.forEach(textCommand => this.textCommandsService.add(textCommand, prefix));
 	}
 
 	public onApplicationBootstrap() {
@@ -34,14 +36,8 @@ export class TextCommandsModule implements OnApplicationBootstrap, OnModuleInit 
 				return;
 
 			const content = message.content.toLowerCase();
-			const prefix =
-				typeof this.options.prefix !== 'function'
-					? (this.options.prefix ?? '!')
-					: await this.options.prefix(message);
 
-			if (!prefix || !content.startsWith(prefix)) return;
-
-			const args = content.substring(prefix.length).split(/ +/g);
+			const args = content.split(/ +/g);
 			const cmd = args.shift();
 
 			if (!cmd) return;

--- a/src/text-commands/text-commands.module.ts
+++ b/src/text-commands/text-commands.module.ts
@@ -34,23 +34,26 @@ export class TextCommandsModule implements OnApplicationBootstrap, OnModuleInit 
 				return;
 
 			const content = message.content.toLowerCase();
-			
-			let args: string[] = [];
-			let cmd: string | undefined;
 
 			const prefix =
 				typeof this.options.prefix !== 'function'
 					? (this.options.prefix ?? '!')
 					: await this.options.prefix(message);
 
-			if (prefix && content.startsWith(prefix)) {
-				const contentWithoutPrefix = content.slice(prefix.length);
-				args = contentWithoutPrefix.split(/ +/g);
-				cmd = args.shift();
-			} else {
-				args = content.split(/ +/g);
-				cmd = args.shift();
+			let contentWithoutPrefix: string;
+
+			const hasPrefix = prefix && content.startsWith(prefix);
+
+			if (hasPrefix) {
+				contentWithoutPrefix = content.slice(prefix.length);
+			} else if (this.options.allowTextCommandsWithoutPrefix) {
+				contentWithoutPrefix = content;
 			}
+
+			if (!contentWithoutPrefix) return;
+
+			const args = contentWithoutPrefix.trim().split(/ +/g);
+			const cmd = args.shift();
 
 			if (!cmd) return;
 

--- a/src/text-commands/text-commands.service.ts
+++ b/src/text-commands/text-commands.service.ts
@@ -14,17 +14,21 @@ export class TextCommandsService {
 
 	public add(textCommand: TextCommandDiscovery) {
 		const name = textCommand.getName();
-		const aliases = textCommand.getAliases() || [];
+		const aliases = textCommand.getAliases();
 
 		if (this.cache.has(name)) {
 			this.logger.warn(`TextCommand : ${name} already exists`);
 		}
 
-		aliases.forEach((aliase) => {
-			this.cache.set(aliase, textCommand);
-		});
+		const variants = [name, ...aliases];
 
-		this.cache.set(name, textCommand);
+		for (const variant of variants) {
+			if (this.cache.has(variant)) {
+				this.logger.warn(`TextCommand : ${variant} already exists`);
+			}
+
+			this.cache.set(variant, textCommand);
+		}
 	}
 
 	public get(name: string) {

--- a/src/text-commands/text-commands.service.ts
+++ b/src/text-commands/text-commands.service.ts
@@ -12,14 +12,19 @@ export class TextCommandsService {
 
 	public readonly cache = new Collection<string, TextCommandDiscovery>();
 
-	public add(textCommand: TextCommandDiscovery) {
+	public add(textCommand: TextCommandDiscovery, prefix) {
 		const name = textCommand.getName();
+		const aliases = textCommand.getAliases() || [];
 
 		if (this.cache.has(name)) {
 			this.logger.warn(`TextCommand : ${name} already exists`);
 		}
 
-		this.cache.set(name, textCommand);
+		aliases.forEach((aliase) => {
+			this.cache.set(aliase, textCommand);
+		});
+
+		this.cache.set(`${prefix ?? ""}${name}`, textCommand);
 	}
 
 	public get(name: string) {

--- a/src/text-commands/text-commands.service.ts
+++ b/src/text-commands/text-commands.service.ts
@@ -12,7 +12,7 @@ export class TextCommandsService {
 
 	public readonly cache = new Collection<string, TextCommandDiscovery>();
 
-	public add(textCommand: TextCommandDiscovery, prefix) {
+	public add(textCommand: TextCommandDiscovery) {
 		const name = textCommand.getName();
 		const aliases = textCommand.getAliases() || [];
 
@@ -24,7 +24,7 @@ export class TextCommandsService {
 			this.cache.set(aliase, textCommand);
 		});
 
-		this.cache.set(`${prefix ?? ""}${name}`, textCommand);
+		this.cache.set(name, textCommand);
 	}
 
 	public get(name: string) {

--- a/test/text-commands/text-commands.module.spec.ts
+++ b/test/text-commands/text-commands.module.spec.ts
@@ -41,7 +41,7 @@ describe('TextCommandsModule', () => {
 			.compile();
 
 		const instance = moduleRef.get(TextCommandsModule);
-		instance.onModuleInit();
+		await instance.onModuleInit();
 		instance.onApplicationBootstrap();
 
 		// simulate client.on('messageCreate')

--- a/test/text-commands/text-commands.module.spec.ts
+++ b/test/text-commands/text-commands.module.spec.ts
@@ -17,7 +17,7 @@ describe('TextCommandsModule', () => {
 	let explorerService: NecordExplorerService<TextCommandDiscovery>;
 	let emitMessageCreate: (message: Partial<Message>) => void;
 
-	beforeEach(async () => {
+	const createModule = async (options: Record<string, unknown> = { prefix: '!' }) => {
 		client = new Client({ intents: [] });
 		textCommandsService = { add: jest.fn(), get: jest.fn() } as any;
 		explorerService = {
@@ -31,7 +31,7 @@ describe('TextCommandsModule', () => {
 			]
 		})
 			.overrideProvider(NECORD_MODULE_OPTIONS)
-			.useValue({ prefix: '!' })
+			.useValue(options)
 			.overrideProvider(Client)
 			.useValue(client)
 			.overrideProvider(TextCommandsService)
@@ -49,6 +49,10 @@ describe('TextCommandsModule', () => {
 			const listener = client.rawListeners('messageCreate')[0];
 			if (listener) listener(message);
 		};
+	};
+
+	beforeEach(async () => {
+		await createModule();
 	});
 
 	it('should add commands on module init', () => {
@@ -70,11 +74,32 @@ describe('TextCommandsModule', () => {
 		expect(execute).toHaveBeenCalledWith([msg]);
 	});
 
+	it('should ignore messages without prefix by default', () => {
+		emitMessageCreate({ content: 'hello', author: { bot: false } } as any);
+
+		expect(textCommandsService.get).not.toHaveBeenCalled();
+	});
+
+	it('should handle messages without prefix when allowed globally', async () => {
+		await createModule({ prefix: '!', allowTextCommandsWithoutPrefix: true });
+
+		const execute = jest.fn();
+		(textCommandsService.get as jest.Mock).mockReturnValue({ execute });
+
+		const msg = {
+			content: 'hello',
+			author: { bot: false }
+		};
+
+		emitMessageCreate(msg as any);
+		expect(textCommandsService.get).toHaveBeenCalledWith('hello');
+		expect(execute).toHaveBeenCalledWith([msg]);
+	});
+
 	it('should ignore bot messages and invalid formats', () => {
 		emitMessageCreate({ content: '', author: { bot: true } } as any);
 		emitMessageCreate({ content: null, author: { bot: false } } as any);
 		emitMessageCreate({ content: 'hi', webhookId: '123', author: { bot: false } } as any);
-		emitMessageCreate({ content: 'hi', author: { bot: false } } as any);
 
 		expect(textCommandsService.get).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
This pull request lets a @TextCommand carry extra names - a developer may list any number of those aliases - each alias works like the original command word.

Because the extra names are usually short, the command is faster to type and easier to remember.

**Before: **

@TextCommand({
name: 'ban',
description: 'Ban a user from the server',
})

**After: **

@TextCommand({
name: 'ban',
description: 'Ban a user from the server',
aliases: ['bn'],
})

The server now accepts both words

prefix + ban
bn

Benefits

The developer has a smoother experience. 
Commands become shorter and friendlier for the user. 
Commands that already exist do not break.

Notes

The change does not break earlier code. 
Commands that have no aliases behave exactly as before.