### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-pkg.pr.new.yml
+++ b/.github/workflows/publish-pkg.pr.new.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - '!**'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
Potential fix for [https://github.com/necordjs/necord/security/code-scanning/18](https://github.com/necordjs/necord/security/code-scanning/18)

Add an explicit `permissions` block in `.github/workflows/publish-pkg.pr.new.yml` at the workflow root so it applies to all jobs (including `publish`). The minimal safe baseline is `contents: read`, which satisfies checkout and enforces least privilege by default. This change does not alter workflow logic or triggers; it only constrains token scope explicitly.

Best single fix here: insert

```yml
permissions:
  contents: read
```

between the `on:` section and `jobs:` section (or just before `jobs:`), preserving existing behavior while addressing the CodeQL alert.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
